### PR TITLE
Add -y parameter to conda install

### DIFF
--- a/getting_started_notebooks/basics/Getting_Started_with_cuDF.ipynb
+++ b/getting_started_notebooks/basics/Getting_Started_with_cuDF.ipynb
@@ -86,8 +86,8 @@
    "source": [
     "!apt update\n",
     "!apt install -y graphviz\n",
-    "!conda install graphviz\n",
-    "!conda install python-graphviz"
+    "!conda -y install graphviz\n",
+    "!conda -y install python-graphviz"
    ]
   },
   {


### PR DESCRIPTION
Hi,

I have added the parameter '-y' to the following conda install sentences, in order to force the install.

> !conda -y install graphviz
> !conda -y install python-graphviz

If that parameter is not present, the command line asks if the dependencies must be installed, and the notebook is not interactive, so the cell does not successfully ends its execution.

Hope it helps!
Miguel